### PR TITLE
feat: Realtime Database 에뮬레이터 설정 추가

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -25,6 +25,9 @@
     "ui": {
       "enabled": true
     },
-    "singleProjectMode": true
+    "singleProjectMode": true,
+    "database": {
+      "port": 9000
+    }
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
-    "serve": "npm run build && firebase emulators:start --only functions",
+    "serve": "npm run build && firebase emulators:start",
     "serve:clean": "rm -rf lib && npm run serve",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",


### PR DESCRIPTION
## Summary

- Local 에서 데이터베이스까지 emulator로 테스트 가능하도록 설정 추가
- `firebase init emulators` 명령어 1회 수행 필요

## Screenshot

<img width="1436" alt="Screen Shot 2023-01-18 at 9 18 47 PM" src="https://user-images.githubusercontent.com/32405358/213169654-2c355b50-e18b-4105-82e1-6357286c6252.png">
