### PR TITLE
Create Meeting API 추가

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "functions",
       "dependencies": {
+        "class-validator": "^0.14.0",
         "dotenv": "^16.0.3",
         "firebase": "^9.13.0",
         "firebase-admin": "^10.0.2",
@@ -831,6 +832,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.7.11",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.11.tgz",
+      "integrity": "sha512-WqTos+CnAKN64YwyBMhgUYhb5VsTNKwUY6AuzG5qu9/pFZJar/RJFMZBXwX7VS+uzYi+lIAr3WkvuWqEI9F2eg=="
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1014,6 +1020,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
+      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
+      "dependencies": {
+        "@types/validator": "^13.7.10",
+        "libphonenumber-js": "^1.10.14",
+        "validator": "^13.7.0"
       }
     },
     "node_modules/cliui": {
@@ -1990,6 +2006,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.10.18",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.18.tgz",
+      "integrity": "sha512-NS4ZEgNhwbcPz1gfSXCGFnQm0xEiyTSPRthIuWytDzOiEG9xnZ2FbLyfJC4tI2BMAAXpoWbNxHYH75pa3Dq9og=="
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -2793,6 +2814,14 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {
@@ -3649,6 +3678,11 @@
         "@types/node": "*"
       }
     },
+    "@types/validator": {
+      "version": "13.7.11",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.11.tgz",
+      "integrity": "sha512-WqTos+CnAKN64YwyBMhgUYhb5VsTNKwUY6AuzG5qu9/pFZJar/RJFMZBXwX7VS+uzYi+lIAr3WkvuWqEI9F2eg=="
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3786,6 +3820,16 @@
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      }
+    },
+    "class-validator": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
+      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
+      "requires": {
+        "@types/validator": "^13.7.10",
+        "libphonenumber-js": "^1.10.14",
+        "validator": "^13.7.0"
       }
     },
     "cliui": {
@@ -4588,6 +4632,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.10.18",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.18.tgz",
+      "integrity": "sha512-NS4ZEgNhwbcPz1gfSXCGFnQm0xEiyTSPRthIuWytDzOiEG9xnZ2FbLyfJC4tI2BMAAXpoWbNxHYH75pa3Dq9og=="
+    },
     "lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -5216,6 +5265,11 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -5,6 +5,7 @@
     "build:watch": "tsc --watch",
     "serve": "npm run build && firebase emulators:start --only functions",
     "serve:clean": "rm -rf lib && npm run serve",
+    "serve:watch": "npm run build:watch | firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,6 +16,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
+    "class-validator": "^0.14.0",
     "dotenv": "^16.0.3",
     "firebase": "^9.13.0",
     "firebase-admin": "^10.0.2",

--- a/functions/src/functions/meeting.ts
+++ b/functions/src/functions/meeting.ts
@@ -37,7 +37,7 @@ const getMeeting = async (request: functions.https.Request, response: functions.
 const postMeeting = async (request: functions.https.Request, response: functions.Response) => {
   functions.logger.info("POST Meeting!", { structuredData: true });
   // Input validation
-  const createMeetingDto = request.body as CreateMeetingDto;
+  const createMeetingDto: CreateMeetingDto = request.body;
 
   // Call meetings service to create meeting
   const createdMeeting = await createMeeting(createMeetingDto);

--- a/functions/src/functions/meeting.ts
+++ b/functions/src/functions/meeting.ts
@@ -1,42 +1,57 @@
 import * as functions from "firebase-functions";
-import { MeetingModel } from "../model/Meeting";
+// import { MeetingModel } from "../model/Meeting";
 
 // NOTE: Meeting 생성 샘플
-
-export const createMeeting2 = functions.https.onRequest(async (request, response) => {
-  functions.logger.info("create Meeting!", { structuredData: true });
-
+export const meetings = functions.https.onRequest(async (request, response) => {
   try {
-    const Meeting = new MeetingModel();
-
-    const result = await Meeting.create({
-      name: "test",
-      dates: [],
-      types: "meal",
-      status: "in progress",
-    });
-
-    response.send(result);
-  } catch (err) {
-    response.send(err);
+    switch (request.method) {
+      case 'GET':
+        await getMeeting(request, response);
+        break;
+      case 'POST':
+        await postMeeting(request, response);
+        break;
+      case 'PUT':
+        await putMeeting(request, response);
+        break;
+      default:
+        response.status(405).send('Method Not Allowed');
+        break;
+    }
+  } catch (error) {
+    response.send(error);
   }
-});
+})
 
-export const createMeeting3 = functions.https.onRequest(async (request, response) => {
-  functions.logger.info("create Meeting!", { structuredData: true });
+export const getMeeting = async (request: functions.https.Request, response: functions.Response) => {
+  functions.logger.info("GET Meeting!", { structuredData: true });
+  // Stub
+  response.send({
+    name: "test",
+    dates: [],
+    types: "meal",
+    status: "in progress",
+  })
+}
 
-  try {
-    const Meeting = new MeetingModel();
+export const postMeeting = async (request: functions.https.Request, response: functions.Response) => {
+  functions.logger.info("POST Meeting!", { structuredData: true });
+  // Stub
+  response.send({
+    name: "test",
+    dates: [],
+    types: "meal",
+    status: "in progress",
+  })
+}
 
-    const result = await Meeting.create({
-      name: "test",
-      dates: [],
-      types: "meal",
-      status: "in progress",
-    });
-
-    response.send(result);
-  } catch (err) {
-    response.send(err);
-  }
-});
+export const putMeeting = async (request: functions.https.Request, response: functions.Response) => {
+  functions.logger.info("PUT Meeting!", { structuredData: true });
+  // Stub 
+  response.send({
+    name: "test",
+    dates: [],
+    types: "meal",
+    status: "in progress",
+  })
+}

--- a/functions/src/functions/meeting.ts
+++ b/functions/src/functions/meeting.ts
@@ -1,7 +1,6 @@
 import * as functions from "firebase-functions";
 import { createMeeting } from "../services/meetings";
 import { CreateMeetingDto } from "../types";
-// import { MeetingModel } from "../model/Meeting";
 
 export const meetings = functions.https.onRequest(async (request, response) => {
   try {
@@ -24,7 +23,7 @@ export const meetings = functions.https.onRequest(async (request, response) => {
   }
 })
 
-export const getMeeting = async (request: functions.https.Request, response: functions.Response) => {
+const getMeeting = async (request: functions.https.Request, response: functions.Response) => {
   functions.logger.info("GET Meeting!", { structuredData: true });
   // Stub
   response.send({
@@ -35,7 +34,7 @@ export const getMeeting = async (request: functions.https.Request, response: fun
   })
 }
 
-export const postMeeting = async (request: functions.https.Request, response: functions.Response) => {
+const postMeeting = async (request: functions.https.Request, response: functions.Response) => {
   functions.logger.info("POST Meeting!", { structuredData: true });
   // Input validation
   const createMeetingDto = request.body as CreateMeetingDto;
@@ -47,7 +46,7 @@ export const postMeeting = async (request: functions.https.Request, response: fu
   response.send(createdMeeting)
 }
 
-export const putMeeting = async (request: functions.https.Request, response: functions.Response) => {
+const putMeeting = async (request: functions.https.Request, response: functions.Response) => {
   functions.logger.info("PUT Meeting!", { structuredData: true });
   // Stub 
   response.send({

--- a/functions/src/functions/meeting.ts
+++ b/functions/src/functions/meeting.ts
@@ -1,7 +1,8 @@
 import * as functions from "firebase-functions";
+import { createMeeting } from "../services/meetings";
+import { CreateMeetingDto } from "../types";
 // import { MeetingModel } from "../model/Meeting";
 
-// NOTE: Meeting 생성 샘플
 export const meetings = functions.https.onRequest(async (request, response) => {
   try {
     switch (request.method) {
@@ -36,13 +37,14 @@ export const getMeeting = async (request: functions.https.Request, response: fun
 
 export const postMeeting = async (request: functions.https.Request, response: functions.Response) => {
   functions.logger.info("POST Meeting!", { structuredData: true });
-  // Stub
-  response.send({
-    name: "test",
-    dates: [],
-    types: "meal",
-    status: "in progress",
-  })
+  // Input validation
+  const createMeetingDto = request.body as CreateMeetingDto;
+
+  // Call meetings service to create meeting
+  const createdMeeting = await createMeeting(createMeetingDto);
+
+  // Return created meeting in proper format
+  response.send(createdMeeting)
 }
 
 export const putMeeting = async (request: functions.https.Request, response: functions.Response) => {

--- a/functions/src/model/Model.ts
+++ b/functions/src/model/Model.ts
@@ -54,7 +54,7 @@ export abstract class Model<T> {
     const id = uuidv4();
 
     return new Promise<WithId<T>>((resolve, reject) => {
-      set(ref(this.database, `${this.path}/${uuidv4()}`), { ...document })
+      set(ref(this.database, `${this.path}/${id}`), { ...document })
         .then(() => {
           resolve({ id, ...document });
         })

--- a/functions/src/model/Model.ts
+++ b/functions/src/model/Model.ts
@@ -9,6 +9,7 @@ import {
   remove,
   set,
 } from "firebase/database";
+import { WithId } from "../types";
 
 export abstract class Model<T> {
   prefixPath: string;
@@ -50,10 +51,12 @@ export abstract class Model<T> {
   }
 
   create(document: T) {
-    return new Promise<T>((resolve, reject) => {
+    const id = uuidv4();
+
+    return new Promise<WithId<T>>((resolve, reject) => {
       set(ref(this.database, `${this.path}/${uuidv4()}`), { ...document })
         .then(() => {
-          resolve(document);
+          resolve({ id, ...document });
         })
         .catch(reject);
     });

--- a/functions/src/services/meetings.ts
+++ b/functions/src/services/meetings.ts
@@ -1,0 +1,16 @@
+import { MeetingModel } from '../model/Meeting';
+import { CreateMeetingDto } from '../types'
+
+const meetingModel = new MeetingModel();
+
+export const createMeeting = async ({ name, dates, type, deadline, password }: CreateMeetingDto) => {
+  const createdMeeting = await meetingModel.create({
+    name,
+    dates,
+    type,
+    status: 'in progress',
+    deadline,
+  });
+
+  return createdMeeting;
+}

--- a/functions/src/services/meetings.ts
+++ b/functions/src/services/meetings.ts
@@ -1,15 +1,23 @@
 import { MeetingModel } from '../model/Meeting';
 import { CreateMeetingDto } from '../types'
+import { createHash } from 'crypto';
 
 const meetingModel = new MeetingModel();
 
 export const createMeeting = async ({ name, dates, type, deadline, password }: CreateMeetingDto) => {
+  let passwordHash = undefined;
+  
+  if(password !== undefined) {
+    passwordHash = createHash('sha256').update(password).digest('hex');
+  }
+  
   const createdMeeting = await meetingModel.create({
     name,
     dates,
     type,
     status: 'in progress',
     deadline,
+    ...(password ? { password: passwordHash } : {})
   });
 
   return createdMeeting;

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -1,14 +1,18 @@
 type Meal = "lunch" | "dinner";
+export type ISODateTime = string;
+export type WithId<T> = T & { id: string };
 
 export type Meeting = {
   name: string;
-  dates: string[];
-  types: "date" | "meal";
+  dates: ISODateTime[];
+  type: "date" | "meal";
   status: "in progress" | "done";
+  deadline: ISODateTime;
   selectedDate?: {
     date: string;
     meal: Meal;
   };
+  password?: string; // sha256 hashed value in database
 };
 
 export type User = {
@@ -25,3 +29,5 @@ type Vote = {
   date: string;
   meal?: Meal;
 };
+
+export type CreateMeetingDto = Pick<Meeting, 'name' | 'dates' | 'type' | 'deadline' | 'password'>

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -1,12 +1,15 @@
 type Meal = "lunch" | "dinner";
+  /** ISO8601 DateTime 형식 */
 export type ISODateTime = string;
 export type WithId<T> = T & { id: string };
 
 export type Meeting = {
   name: string;
+  /** ISO8601 DateTime 형식의 목록 */
   dates: ISODateTime[];
   type: "date" | "meal";
   status: "in progress" | "done";
+  /** ISO8601 DateTime 형식 */
   deadline: ISODateTime;
   selectedDate?: {
     date: string;


### PR DESCRIPTION
## Summary

- 모임 생성 API 추가
- controller(functions), service, model 분리
- password hashing 저장 추가

## How to test

- npm run serve:watch 실행
- 아래 curl을 이용해서 API 호출

```
curl --location --request POST 'http://127.0.0.1:5001/to-be-determined-8620e/us-central1/meetings' \
--header 'Content-Type: application/json' \
--data-raw '{
    "name": "meetingName",
    "dates": [
        "2023-01-25T00:00:00.000Z",
        "2023-01-26T00:00:00.000Z"
    ],
    "type": "meal",
    "deadline": "2023-01-28T00:00:00.000Z",
    "password": "1234"
}'
```

## ToDo

- class validator를 이용한 input 값 검증