### PR TITLE
GET meeting API 추가

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -5,7 +5,7 @@
     "build:watch": "tsc --watch",
     "serve": "npm run build && firebase emulators:start",
     "serve:clean": "rm -rf lib && npm run serve",
-    "serve:watch": "npm run build:watch | firebase emulators:start --only functions",
+    "serve:watch": "npm run build:watch | firebase emulators:start",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",

--- a/functions/src/services/meetings.ts
+++ b/functions/src/services/meetings.ts
@@ -22,3 +22,9 @@ export const createMeeting = async ({ name, dates, type, deadline, password }: C
 
   return createdMeeting;
 }
+
+export const findMeeting = async (meetingId: string) => {
+  const meeting = await meetingModel.find(meetingId);
+  
+  return meeting;
+}


### PR DESCRIPTION
closes #13 

## Summary

- /meetings/:meetingId 경로로 호출하는 단일 meeting 조회 API 추가

## Request

```sh
curl --location 'http://127.0.0.1:5001/to-be-determined-8620e/us-central1/meetings/f7e5304b-43c1-4d97-b523-03fcdf7107e4'
```

## Response

```json
{
    "id": "f7e5304b-43c1-4d97-b523-03fcdf7107e4",
    "dates": [
        "2023-01-25T00:00:00.000Z",
        "2023-01-26T00:00:00.000Z"
    ],
    "deadline": "2023-01-28T00:00:00.000Z",
    "name": "meetingName",
    "status": "in progress",
    "type": "meal"
}
```