### PR TITLE
voting post API에 username validation 추가

### DIFF
--- a/functions/src/functions/meetingRouters/voting.ts
+++ b/functions/src/functions/meetingRouters/voting.ts
@@ -9,42 +9,47 @@ import { Meeting, Voting } from '../../types';
 
 const router = express.Router();
 
+class HttpError extends Error {
+  constructor(public code: number, public message: string) {
+    super();
+  }
+}
+
 router.post(`/:meetingId/votings`, async (req, res) => {
   functions.logger.info('POST VOTING!', { structuredData: true });
   const { meetingId } = req.params;
 
   const createVotingDto = plainToInstance(CreateVotingDto, req.body);
 
-  const validateMeeting = new Promise<void>(async (resolve, reject) => {
+  const validateMeeting = async () => {
     const meeting = await findMeeting(meetingId);
     if (meeting === null) {
-      return reject({ code: 404, message: 'Not found Meeting Info' });
+      throw new HttpError(404, 'Not found Meeting Info');
     }
     if (meeting.status === 'done') {
-      return reject({ code: 400, message: 'Meeting Already Closed' });
+      throw new HttpError(404, 'Not found Meeting Info');
     }
 
     // 유효성 검사
     if (isValidateMeetingInput(createVotingDto, meeting) === false) {
-      return reject({ code: 422, message: 'Invalid input, Selected Date not included in Meeting' });
+      throw new HttpError(422, 'Invalid input, Selected Date not included in Meeting');
     }
+  };
 
-    resolve();
-  });
-
-  const validateUsernameNotExist = new Promise<void>(async (resolve, reject) => {
+  const validateUsernameNotExist = async () => {
     const voting = await getVotings(meetingId, createVotingDto.username);
     if (voting) {
-      return reject({ code: 422, message: 'username Already Exists.' });
+      throw new HttpError(422, 'username Already Exists.');
     }
-    resolve();
-  });
+  };
 
   try {
     await Promise.all([validateMeeting, validateUsernameNotExist]);
   } catch (e) {
-    const error = e as { code: number; message: string };
-    return res.status(error.code).send({ message: error.message });
+    if (e instanceof HttpError) {
+      return res.status(e.code).send({ message: e.message });
+    }
+    return res.status(404).send({ message: 'Validation Failed' });
   }
 
   const createdVoting = await createVoting(meetingId, createVotingDto);

--- a/functions/src/functions/meetingRouters/voting.ts
+++ b/functions/src/functions/meetingRouters/voting.ts
@@ -19,7 +19,6 @@ router.post(`/:meetingId/votings`, async (req, res) => {
     const meeting = await findMeeting(meetingId);
     if (meeting === null) {
       return reject({ code: 404, message: 'Not found Meeting Info' });
-      return;
     }
     if (meeting.status === 'done') {
       return reject({ code: 400, message: 'Meeting Already Closed' });


### PR DESCRIPTION
https://github.com/Team-Panopticon/TBD-client/issues/104

- `/:meetingId/votings` post API에 username validation 추가

  - 기존 meeting validation과 새로 추가한 username validation을 각각의 Promise로 실행

  - Promise.all로 하나라도 reject될 경우 에러 응답

---

### 논의 사항

- voting post API에 meeting을 조회하여 validation하는 로직이 있어 voting까지 조회하면 2개의 Promise를 순서대로 호출해야 해서 각각을 Promise로 만들어서 Promise.all으로 비동기를 처리했습니다

  - 2개의 validation 로직을 이어서 배치하는것 보다 코드가 덜 직관적이라는 느낌이 있네요
  - 2개의 validaiton을 이어서 배치할 경우 하나씩 validation해서 DB를 접근하는 횟수가 작을 수 있지만 (첫 번째 validation에서 바로 reject되는 경우)
    2번의 비동기를 순차적으로 처리해야하므로 응답 속도가 느려지는 단점도 존재할것 같은데... 어떻게 생각하시나요?