### PR TITLE
Public 상태의 meeting에 대해서 비밀번호 없이 토큰발급 기능 추가

### DIFF
--- a/functions/src/dtos/votings.ts
+++ b/functions/src/dtos/votings.ts
@@ -17,6 +17,7 @@ export class VotingSlotDto implements Slot {
   @IsDateString()
   date: string;
 
+  @IsOptional()
   @IsString()
   @Matches(/^lunch|dinner$/)
   meal?: Meal;

--- a/functions/src/functions/meetingRouters/meeting.ts
+++ b/functions/src/functions/meetingRouters/meeting.ts
@@ -20,7 +20,7 @@ router.post('/:meetingId/auth', async (req, res) => {
     return res.status(404).send({ message: 'Not found' });
   }
 
-  const isPrivateMeeting = meeting.access === 'private';
+  const isPrivateMeeting = meeting.adminAccess === 'private';
   const password = req.body.password;
   const hashedPassword = isPrivateMeeting ? createHash('sha256').update(password).digest('hex') : undefined;
 

--- a/functions/src/functions/meetingRouters/meeting.ts
+++ b/functions/src/functions/meetingRouters/meeting.ts
@@ -54,7 +54,7 @@ router.post('/:meetingId/confirm', async (req, res) => {
     return res.status(401).send({ message: 'Authorize Failed' });
   }
 
-  const votingSlotDto = plainToInstance(VotingSlotDto, req.body);
+  const votingSlotDto = plainToInstance(VotingSlotDto, req.body);  
   try {
     await validateOrReject(votingSlotDto);
   } catch (errors) {
@@ -63,7 +63,7 @@ router.post('/:meetingId/confirm', async (req, res) => {
 
   await confirmMeeting(meetingId, votingSlotDto);
 
-  return res.status(201);
+  return res.status(201).send();
 });
 
 router.get('/:meetingId', async (req, res) => {

--- a/functions/src/services/meetings.ts
+++ b/functions/src/services/meetings.ts
@@ -20,6 +20,7 @@ export const createMeeting = async ({ name, dates, type, password }: CreateMeeti
     // HACK: Firebase does not accept object with undefined value
     // Don't add 'password' key in object when password is undefined
     ...(password ? { password: passwordHash } : {}),
+    access: password ? 'private' : 'public',
   });
 
   return createdMeeting;

--- a/functions/src/services/meetings.ts
+++ b/functions/src/services/meetings.ts
@@ -20,7 +20,7 @@ export const createMeeting = async ({ name, dates, type, password }: CreateMeeti
     // HACK: Firebase does not accept object with undefined value
     // Don't add 'password' key in object when password is undefined
     ...(password ? { password: passwordHash } : {}),
-    access: password ? 'private' : 'public',
+    adminAccess: password ? 'private' : 'public',
   });
 
   return createdMeeting;

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -14,6 +14,7 @@ export type Meeting = {
   status: 'inProgress' | 'done';
   password?: string; // sha256 hashed value in database
   confirmedDateType?: Slot;
+  access: 'public' | 'private';
 };
 
 export type Voting = {

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -14,7 +14,7 @@ export type Meeting = {
   status: 'inProgress' | 'done';
   password?: string; // sha256 hashed value in database
   confirmedDateType?: Slot;
-  access: 'public' | 'private';
+  adminAccess: 'public' | 'private';
 };
 
 export type Voting = {


### PR DESCRIPTION
## Summary

- 비밀번호 설정을 생략한 meeting은 access: public으로 설정
- Meeting 조회 API에 access 필드 응답
- public meeting의 경우 비밀번호 없이 토큰 발급기능 추가