### PR TITLE
feat: Cold start 방지용 API 경로 추가

### DIFF
--- a/functions/src/functions/index.ts
+++ b/functions/src/functions/index.ts
@@ -11,5 +11,10 @@ app.use(corsMiddleware);
 
 app.use('/meetings', MeetingRouters);
 
+// Stub API for preventing cold start
+app.get('/warmer', (req, res) => {
+  res.send('Warming cloud functions instance')
+})
+
 export const v1 = functions.https.onRequest(app);
 export const dev = v1;


### PR DESCRIPTION
- Meeting 생성 페이지에서는 미팅 생성 시 최초 API를 호출하게 됨
- Cloud functions가 켜지지 않은 상태인 경우 cold start 발생하여 모임 생성 API 호출이 오래걸림 (미팅생성 + 미팅조회 5초)
- Meeting 생성 페이지 접속 직후에 warmUp API를 의도적으로 호출해서 모임정보를 작성하는 동안 cloud functions를 키고 cold start를 예방

https://github.com/Team-Panopticon/TBD-client/pull/244